### PR TITLE
Guard against empty from values. Add README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# twilio-opt-out
+
+A Twilio Function for creating an opt-out workflow in Customer.io. See [this tutorial](https://customer.io/docs/sms-keywords/) for more information.

--- a/function.js
+++ b/function.js
@@ -21,6 +21,11 @@ exports.handler = async function (context, event, callback) {
         return callback('Set your track API credentials in environment variables');
     }
 
+    let from = event.from || event.From;
+    if (from == null || from == '') {
+        return callback("The 'from' key must be set on the event object.");
+    }
+
     try {
         
         // If an axios request returns an error, retry 3 times

--- a/function.js
+++ b/function.js
@@ -21,7 +21,7 @@ exports.handler = async function (context, event, callback) {
         return callback('Set your track API credentials in environment variables');
     }
 
-    let from = event.from || event.From;
+    let from = event.from;
     if (from == null || from == '') {
         return callback("The 'from' key must be set on the event object.");
     }
@@ -47,7 +47,7 @@ exports.handler = async function (context, event, callback) {
                             attribute: {
                                 field: 'phone',
                                 operator: 'eq',
-                                value: event.from
+                                value: from
                             }
                         }
                     ]


### PR DESCRIPTION
Don't proceed if `event.from` isn't available; otherwise we'll unsubscribe everyone _without_ a `phone` attribute value.